### PR TITLE
prevents issue with dropdowns being cut-off within the accordion when…

### DIFF
--- a/src/lib/VueAccordion.vue
+++ b/src/lib/VueAccordion.vue
@@ -50,14 +50,17 @@ export default Vue.extend({
 
   methods: {
     onEnter(el) {
+      el.style.overflow = 'hidden'
       this.setWrapperHeightTo(this.getContentHeight(), el)
     },
 
     onAfterEnter(el) {
+      el.style.overflow = ''
       this.setWrapperHeightTo('auto', el)
     },
 
     onBeforeLeave(el) {
+      el.style.overflow = 'hidden'
       this.setWrapperHeightTo(this.getContentHeight(), el)
     },
 
@@ -86,7 +89,6 @@ export default Vue.extend({
   transition-timing-function ease
   transition-property height
   height 0
-  overflow hidden
 
   &__inner
     display table


### PR DESCRIPTION
… not animating.

This is based off the old version 0.3.0 because the newer version doesn't seem to work with Vue 2. Putting in a PR anyways in case someone wants to fix this for the Vue 3 version!